### PR TITLE
[DH-375] added logic block to skip deletion of WAMF.txt at the root level

### DIFF
--- a/archiver/scanner.py
+++ b/archiver/scanner.py
@@ -240,6 +240,8 @@ def process_dir(p, cutoff_date, ignored_filenames, object_prefix, notice_file_na
                 for subchild in p.iterdir():
                     if subchild.name in ignored_filenames:
                         continue
+                    if subchild.name == notice_file_name:
+                        continue
                     if subchild.is_dir():
                         shutil.rmtree(subchild)
                     else:


### PR DESCRIPTION
without this, as `ignored_filenames` is initially empty (and we don't pass it in when we execute the script), it will correctly write the file but then immediately delete it.

i noticed in the logs from the summer 2024 run that we were indeed writing the file, so i looked at the deletion code and figured out what was happening.